### PR TITLE
docs(readme): Improve readability by closing theme catalogue section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Visit: `https://github-profile-card-blue.vercel.app/card/{username}?theme={theme
 
 Replace `{username}` with any GitHub username and `{theme}` with one of our 56 available themes listed below.
 
-<details open>
+<details close>
 <summary><b>Complete Thematic Catalogue (56 Variations)</b></summary>
 
 ### Default Theme


### PR DESCRIPTION
here i updates the **README** to collapse the **Complete Thematic Catalogue (56 Variations)** section by default.

Previously, the `<details>` block was set to **`open`**, which caused the README to appear very long and overwhelming on initial load.

### ✅ Changes

* Replaced:

  ```html
  <details open>
  ```

  with:

  ```html
  <details close>
  ```
* Improves first impression and overall readability
* Keeps theme catalogue accessible but non-intrusive
