### PR TITLE
fix: improve type safety, error handling, and add rate limit retry logic

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -49,7 +49,7 @@ function isValidHexColor(color: string): boolean {
 app.get('/', (c) => {
   return c.json({
     name: 'GitHub Profile Card API',
-    version: '0.1.2',
+    version: '0.1.3',
     author: 'Nayan Das (https://github.com/nayandas69)',
     usage: 'GET /card/:username',
     themes: Object.keys(themes),
@@ -177,7 +177,10 @@ app.get('/card/:username', async (c) => {
       return c.json({ error: message }, 500);
     }
 
-    return c.json({ error: 'An unexpected error occurred' }, 500);
+    // Handle non-Error objects
+    const errorMessage =
+      err instanceof Object && 'message' in err ? String(err.message) : String(err);
+    return c.json({ error: errorMessage || 'An unexpected error occurred' }, 500);
   }
 });
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -29,6 +29,45 @@ function getHeaders(): Record<string, string> {
   };
 }
 
+/**
+ * Retry logic for GitHub API requests with exponential backoff.
+ * Handles 429 (rate limit) errors with automatic retry.
+ */
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  maxRetries: number = 3
+): Promise<Response> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const res = await fetch(url, options);
+
+      // If rate limited, wait and retry (except on last attempt)
+      if (res.status === 429 && attempt < maxRetries - 1) {
+        const retryAfter = res.headers.get('Retry-After');
+        const delayMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : 1000 * Math.pow(2, attempt);
+        console.warn(
+          `Rate limited. Retrying in ${delayMs}ms (attempt ${attempt + 1}/${maxRetries})`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+
+      return res;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (attempt < maxRetries - 1) {
+        const delayMs = 1000 * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+
+  throw lastError || new Error('Failed after retries');
+}
+
 /* ---------- GraphQL Queries ---------- */
 
 /**
@@ -115,8 +154,8 @@ const MAX_CACHE_SIZE = 500;
  */
 const CACHE_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
-/** Maximum number of in-flight requests to prevent memory bloat */
-const MAX_IN_FLIGHT_REQUESTS = 100;
+/** Maximum number of in-flight requests to prevent memory bloat (configurable via env) */
+const MAX_IN_FLIGHT_REQUESTS = parseInt(process.env['MAX_IN_FLIGHT_REQUESTS'] ?? '100', 10);
 
 /** In-memory cache entry with expiry and optional in-flight promise */
 interface CacheEntry {
@@ -172,10 +211,8 @@ function sweepExpiredEntries(): void {
  * expired entries proactively. Uses unref() so the timer does not
  * prevent the Node.js process from exiting gracefully.
  */
-const _sweepTimer = setInterval(sweepExpiredEntries, CACHE_SWEEP_INTERVAL_MS);
-if (typeof _sweepTimer === 'object' && 'unref' in _sweepTimer) {
-  _sweepTimer.unref();
-}
+const _sweepTimer: NodeJS.Timer = setInterval(sweepExpiredEntries, CACHE_SWEEP_INTERVAL_MS);
+_sweepTimer.unref();
 
 /** Options for controlling what data to fetch */
 interface FetchOptions {
@@ -217,8 +254,9 @@ async function getRedis(): Promise<import('@upstash/redis').Redis | null> {
  * Downloads a GitHub avatar and converts it to a base64 data URL.
  * This allows the avatar to be embedded directly in the SVG
  * so the card works in contexts that don't support external images.
+ * Falls back to a placeholder SVG data URL if fetch fails.
  */
-async function fetchAvatarDataUrl(url: string): Promise<string | null> {
+async function fetchAvatarDataUrl(url: string): Promise<string> {
   try {
     // Request a smaller 96px version for better performance
     const sizedUrl = `${url}${url.includes('?') ? '&' : '?'}s=96`;
@@ -229,7 +267,7 @@ async function fetchAvatarDataUrl(url: string): Promise<string | null> {
 
     if (!res.ok) {
       console.warn(`Avatar fetch failed: ${res.status} for ${url}`);
-      return null;
+      return getPlaceholderAvatar();
     }
 
     const contentType = res.headers.get('content-type') || 'image/png';
@@ -238,8 +276,18 @@ async function fetchAvatarDataUrl(url: string): Promise<string | null> {
     return `data:${contentType};base64,${base64}`;
   } catch (err) {
     console.warn('Avatar fetch error:', err instanceof Error ? err.message : err);
-    return null;
+    return getPlaceholderAvatar();
   }
+}
+
+/**
+ * Returns a placeholder SVG avatar as a data URL.
+ * Used when avatar fetch fails to ensure a graceful fallback.
+ */
+function getPlaceholderAvatar(): string {
+  const svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96"><rect width="96" height="96" fill="#e0e0e0"/><circle cx="48" cy="32" r="16" fill="#999"/><path d="M 24 72 Q 24 56 48 56 Q 72 56 72 72" fill="#999"/></svg>';
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
 }
 
 /* ---------- Cache Helpers ---------- */
@@ -357,7 +405,7 @@ export async function getProfileData(
       while (hasNextPage && pageCount < maxPages) {
         pageCount++;
 
-        const res = await fetch('https://api.github.com/graphql', {
+        const res = await fetchWithRetry('https://api.github.com/graphql', {
           method: 'POST',
           headers: getHeaders(),
           body: JSON.stringify({


### PR DESCRIPTION
## Changes

### src/services/github.ts
- [x] Fixed `setInterval` type declaration to `NodeJS.Timer` for proper type safety
- [x] Added `getPlaceholderAvatar()` function for graceful avatar fallback (SVG data URL)
- [x] Added `fetchWithRetry()` helper with exponential backoff for 429 rate limit errors
- [x] Made `MAX_IN_FLIGHT_REQUESTS` configurable via environment variable (defaults to 100)
- [x] Updated GraphQL fetch call to use retry logic

### src/app.ts
- [x] Improved error type guard in catch block to handle non-Error objects properly
- [x] Added fallback string conversion for unexpected error types

## Performance Impact

- Retry logic with exponential backoff prevents hammering GitHub API on rate limits
- Placeholder avatar embedded as data URL improves card rendering reliability
- Type safety improvements catch errors at compile time

## Deployment Notes

> [!IMPORTANT]
> Environment variable is optional:
> - `MAX_IN_FLIGHT_REQUESTS=100` (if not set, defaults to 100)
> - No breaking changes, safe to deploy immediately